### PR TITLE
Add basic Linux build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+CXX ?= g++
+CXXFLAGS := -std=c++17 $(shell sdl2-config --cflags) $(shell pkg-config --cflags SDL2_ttf fftw3)
+LDFLAGS := $(shell sdl2-config --libs) $(shell pkg-config --libs SDL2_ttf fftw3)
+
+SRC := main.cpp
+OBJ := $(SRC:.cpp=.o)
+TARGET := iradio
+
+all: $(TARGET)
+
+$(TARGET): $(OBJ)
+	$(CXX) -o $@ $(OBJ) $(LDFLAGS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(TARGET) $(OBJ)
+
+.PHONY: all clean

--- a/configure
+++ b/configure
@@ -17,7 +17,7 @@ check_pkg() {
   fi
 }
 
-check_cmd gcc
+check_cmd g++
 check_cmd sdl2-config
 check_cmd pkg-config
 
@@ -40,4 +40,6 @@ if [ ${#missing[@]} -ne 0 ]; then
   exit 1
 else
   echo "All required tools and libraries are available."
+  echo "Configuration complete. Run 'make' to build."
 fi
+

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,24 @@
+#include <SDL.h>
+#include <SDL_ttf.h>
+#include <fftw3.h>
+#include <iostream>
+
+int main() {
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        std::cerr << "SDL init failed: " << SDL_GetError() << std::endl;
+        return 1;
+    }
+    if (TTF_Init() != 0) {
+        std::cerr << "TTF init failed: " << TTF_GetError() << std::endl;
+        SDL_Quit();
+        return 1;
+    }
+    fftw_complex in[1], out[1];
+    fftw_plan p = fftw_plan_dft_1d(1, in, out, FFTW_FORWARD, FFTW_ESTIMATE);
+    fftw_execute(p);
+    fftw_destroy_plan(p);
+    TTF_Quit();
+    SDL_Quit();
+    std::cout << "Dependencies linked successfully." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add Linux-friendly configure script that checks for g++ and outputs instructions
- introduce Makefile to build a sample SDL/FFTW program
- provide minimal main.cpp demonstrating successful link against SDL2_ttf and FFTW

## Testing
- `sudo apt-get install -y libsdl2-dev libsdl2-ttf-dev libfftw3-dev pkg-config`
- `./configure`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b8a35907cc8326a97f51ea59248caf