### PR TITLE
Check Arduino build dependencies in configure

### DIFF
--- a/configure
+++ b/configure
@@ -10,22 +10,36 @@ check_cmd() {
   fi
 }
 
-check_pkg() {
-  if ! pkg-config --exists "$1"; then
-    echo "Missing required library: $1"
-    missing+=("$1")
+check_lib() {
+  local lib="$1"
+  if ! grep -Fq "$lib" <<<"$lib_list"; then
+    echo "Missing required library: $lib"
+    missing+=("$lib")
   fi
 }
 
-check_cmd g++
-check_cmd sdl2-config
-check_cmd pkg-config
+check_cmd arduino-cli
+check_cmd make
 
-if command -v pkg-config >/dev/null 2>&1; then
-  check_pkg SDL2_ttf
-  check_pkg fftw3
+if command -v arduino-cli >/dev/null 2>&1; then
+  lib_list="$(arduino-cli lib list)"
+  if ! arduino-cli core list | grep -Fq 'esp32:esp32'; then
+    echo "Missing required core: esp32:esp32"
+    missing+=("esp32:esp32 core")
+  fi
+  for lib in \
+    "SimpleRotary" \
+    "Adafruit GFX Library" \
+    "Adafruit SH110X" \
+    "WiFiManager" \
+    "ESP32-audioI2S" \
+    "ArduinoJson" \
+    "StreamUtils"
+  do
+    check_lib "$lib"
+  done
 else
-  echo "pkg-config not found; skipping library checks"
+  echo "arduino-cli not found; skipping core and library checks"
 fi
 
 if [ ${#missing[@]} -ne 0 ]; then
@@ -35,11 +49,12 @@ if [ ${#missing[@]} -ne 0 ]; then
     echo "  - $m"
   done
   echo
-  echo "Install them on Debian/Ubuntu with:"
-  echo "  sudo apt-get install build-essential libsdl2-dev libsdl2-ttf-dev libfftw3-dev pkg-config"
+  echo "Install Arduino CLI from https://arduino.github.io/arduino-cli/latest/installation/"
+  echo "Then run:"
+  echo "  arduino-cli core install esp32:esp32"
+  echo "  arduino-cli lib install SimpleRotary \"Adafruit GFX Library\" Adafruit_SH110X WiFiManager ESP32-audioI2S ArduinoJson StreamUtils"
   exit 1
 else
-  echo "All required tools and libraries are available."
+  echo "All required tools, cores and libraries are available."
   echo "Configuration complete. Run 'make' to build."
 fi
-


### PR DESCRIPTION
## Summary
- ensure `arduino-cli` and `make` are installed
- verify ESP32 core and required Arduino libraries are available
- provide installation instructions for missing components

## Testing
- `./configure` *(fails: Missing required library: WiFiManager, Missing required library: ESP32-audioI2S, Missing required library: StreamUtils)*
- `make` *(fails: fatal error: WiFiManager.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bca73e5354832681ea2ee8d19f4683