### PR TITLE
Ensure required Arduino libs and pre-build checks

### DIFF
--- a/CodexEnvironment
+++ b/CodexEnvironment
@@ -75,6 +75,8 @@ retry 5 5 arduino-cli lib install "ArduinoJson"
 retry 5 5 arduino-cli lib install "Adafruit SH110X"
 retry 5 5 arduino-cli lib install "WiFiManager"
 retry 5 5 arduino-cli lib install "SimpleRotary"
+retry 5 5 arduino-cli lib install "StreamUtils"
+retry 5 5 arduino-cli lib install --git-url https://github.com/schreibfaul1/ESP32-audioI2S.git
 
 echo "✅ Setup complete. Compile with:"
 echo "   arduino-cli compile --fqbn esp32:esp32:esp32 ESP32-internetRadio.ino"

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,17 @@ SKETCH_COPY=ESP32-internetRadio.ino
 BUILD_DIR=build
 BIN=$(BUILD_DIR)/$(SKETCH_COPY).bin
 
-.PHONY: build clean
+.PHONY: build clean check
 
-build:
+build: check
 	cp $(SKETCH) $(SKETCH_COPY)
+	mkdir -p $(BUILD_DIR)
 	arduino-cli compile --fqbn $(FQBN) --output-dir $(BUILD_DIR) $(SKETCH_COPY)
 	@echo "Firmware binary: $(BIN)"
 	rm $(SKETCH_COPY)
+
+check:
+	./configure
 
 clean:
 	rm -rf $(BUILD_DIR) $(SKETCH_COPY)

--- a/configure
+++ b/configure
@@ -67,7 +67,7 @@ if [ ${#missing[@]} -ne 0 ]; then
   echo "Install Arduino CLI from https://arduino.github.io/arduino-cli/latest/installation/"
   echo "Then run:"
   echo "  arduino-cli core install esp32:esp32"
-  echo "  arduino-cli lib install SimpleRotary \"Adafruit GFX Library\" Adafruit_SH110X WiFiManager ArduinoJson StreamUtils"
+  echo "  arduino-cli lib install SimpleRotary \"Adafruit GFX Library\" \"Adafruit SH110X\" WiFiManager ArduinoJson StreamUtils"
   echo "  arduino-cli lib install --git-url https://github.com/schreibfaul1/ESP32-audioI2S.git"
   exit 1
 else


### PR DESCRIPTION
## Summary
- Install StreamUtils and ESP32-audioI2S libraries during environment setup
- Fix configure script install instructions for Adafruit SH110X
- Run configure and create build dir automatically in Makefile

## Testing
- `./configure`
- `make` *(fails: compilation attempted but did not complete within time limit)*

------
https://chatgpt.com/codex/tasks/task_e_68bcab8329488326a234001892135423