### PR TITLE
Fix Makefile sketch path and firmware binary name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@
 # Use a larger partition scheme so the sketch fits in flash
 FQBN=esp32:esp32:esp32:PartitionScheme=huge_app
 
-SKETCH=ESP32-internetRadio.ino
+SKETCH=ESP32-internetRadio/ESP32-internetRadio.ino
 BUILD_DIR=build
-BIN=$(BUILD_DIR)/$(SKETCH).bin
+BIN=$(BUILD_DIR)/$(notdir $(SKETCH)).bin
 
 .PHONY: build clean check
 


### PR DESCRIPTION
### Motivation

- The project sketch is located under `ESP32-internetRadio/` so the Makefile must reference that subdirectory to compile.
- The previous `BIN` path used the full `SKETCH` value which produced an incorrect firmware filename in `build/`.

### Description

- Update `SKETCH` to `ESP32-internetRadio/ESP32-internetRadio.ino` so the compiler finds the sketch.
- Change `BIN` to `$(BUILD_DIR)/$(notdir $(SKETCH)).bin` to use the sketch basename for the firmware file.

### Testing

- Ran `./configure` which reported that all required tools, cores and libraries are available and completed successfully.
- Ran `make` which compiled the sketch successfully and reported the firmware binary as `build/ESP32-internetRadio.ino.bin`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69501de9d620832699b3d31a2601c014)